### PR TITLE
`receiveRequest()` now returns request object

### DIFF
--- a/__tests__/siop-test.ts
+++ b/__tests__/siop-test.ts
@@ -40,9 +40,9 @@ describe('siop', () => {
     const provider = new Provider(expiresIn, consts.defaultResolver);
     // @ts-expect-error 2339
     utils.getRequestObject.mockReturnValueOnce(consts.requestJWT);
-    await expect(provider.receiveRequest(consts.request)).resolves.toBe(
-      consts.client_id,
-    );
+    await expect(
+      provider.receiveRequest(consts.request),
+    ).resolves.toMatchObject({client_id: consts.client_id});
   });
 
   test('receiveRequest() accepts request_uri', async () => {
@@ -52,9 +52,9 @@ describe('siop', () => {
     const request = {request_uri: 'https://example.com', ...consts.request};
     request.request = undefined;
 
-    await expect(provider.receiveRequest(consts.request)).resolves.toBe(
-      consts.client_id,
-    );
+    await expect(
+      provider.receiveRequest(consts.request),
+    ).resolves.toMatchObject({client_id: consts.client_id});
   });
 
   test('receiveRequest() raises errors on validation failure', async () => {

--- a/src/siop.ts
+++ b/src/siop.ts
@@ -52,8 +52,9 @@ export default class Provider {
       this.state,
     );
     const {requestObject} = await validator.validateSIOPRequest(params);
-    this.requestObject = requestObject;
-    return requestObject.client_id;
+    // Deep-copy requestObject to this.requestObject to allow the caller to edit the return value.
+    this.requestObject = JSON.parse(JSON.stringify(requestObject));
+    return requestObject;
   }
   public async generateIDToken(
     request: RequestObject,


### PR DESCRIPTION
This API modification may will be changed again after we discuss it more.