### PR TITLE
Define siop v2 error codes

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -45,10 +45,9 @@ export class SIOPError extends Error {
     ];
 
     const siopCode = [
-      'did_methods_not_supported',
-      'subject_identifier_types_not_supported',
-      'credential_formats_not_supported',
-      'value_not_supported',
+      'user_cancelled',
+      'registration_value_not_supported',
+      'subject_syntax_types_not_supported',
       'invalid_registration_uri',
       'invalid_registration_object',
     ];
@@ -61,7 +60,8 @@ export class SIOPError extends Error {
         'https://openid.net/specs/openid-connect-core-1_0.html#AuthError';
     } else if (siopCode.includes(this.error)) {
       // still in draft
-      params.error_uri = '';
+      params.error_uri =
+        'https://openid.net/specs/openid-connect-self-issued-v2-1_0.html#name-self-issued-openid-provider-e';
     }
     const qs = queryString.stringify(params);
     return `${this.clientId}#${qs}`;

--- a/src/siop-schema.ts
+++ b/src/siop-schema.ts
@@ -164,18 +164,25 @@ export type OIDCCoreErrorCode =
 
 export type SIOPv2ErrorCode =
   // The Self-Issued OP does not support all of the DID methods included in did_methods_supported parameter.
-
-  | 'did_methods_not_supported'
+  // | 'did_methods_not_supported'
   // The Self-Issued OP does not support all of the subject identifier types included in subject_identifier_types_supported parameter.
-  | 'subject_identifier_types_not_supported'
+  // | 'subject_identifier_types_not_supported'
   // The Self-Issued OP does not support all of the credential formats included in credential_formats_supported parameter.
-  | 'credential_formats_not_supported'
+  // | 'credential_formats_not_supported'
   // The Self-Issued OP does not support more than one of the RP Registration Metadata values defined in Section 4.3. When not supported metadata values are DID methods, subject identifier types, or credential formats, more specific error message must be used.
-  | 'value_not_supported'
-  // The registration_uri in the Self-Issued OpenID Provider request returns an error or contains invalid data.
+  // | 'value_not_supported'
+  // ============================== End of did-siop v0.1 error codes ==============================
+  // the registration_uri in the Self-Issued OpenID Provider request returns an error or contains invalid data.
   | 'invalid_registration_uri'
   // The registration parameter contains an invalid RP Registration Metadata Object.
-  | 'invalid_registration_object';
+  | 'invalid_registration_object'
+  // user cancelled the authentication request from the RP.
+  | 'user_cancelled'
+  // the Self-Issued OP does not support some Relying Party Registration metadata values received in the request.
+  | 'registration_value_not_supported'
+  // the Self-Issued OP does not support any of the Subject Syntax Types supported by the RP,
+  // which were communicated in the request in the subject_syntax_types_supported parameter.
+  | 'subject_syntax_types_not_supported';
 
 export type ErrorCode = OIDCCoreErrorCode | OAuth2ErrorCode | SIOPv2ErrorCode;
 /*


### PR DESCRIPTION
We adopted from here: https://openid.net/specs/openid-connect-self-issued-v2-1_0.html#name-self-issued-openid-provider-e