### PR TITLE
CI: Let Codecov Ignore Generated Files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "src/ajv-schemas"  # We generate files in this directory from type declarations
+  - "__tests__"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,3 @@
 ignore:
-  - "src/ajv-schemas"  # We generate files in this directory from type declarations
-  - "__tests__"
+  - "src/ajv-schemas/**"  # We generate files in this directory from type declarations
+  - "__tests__/**"


### PR DESCRIPTION
- Ignoring files under `src/ajv-schemas/` because we generate them using *typescript-json-validator*.
- Ignoring `__tests__/consts.ts`