### PR TITLE
Avoid to Depend on elliptic at production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "crypto-js": "3.3.0",
     "did-jwt": "^5.1.2",
     "did-resolver": "^3.1.0",
-    "elliptic": "^6.5.3",
     "query-string": "^7.0.0"
   },
   "peerDependencies": {
@@ -49,6 +48,7 @@
     "@types/react-native": "^0.67.3",
     "ajv-cli": "3.3.0",
     "babel-jest": "^25.1.0",
+    "elliptic": "^6.5.4",
     "eslint": "^8.11.0",
     "ethr-did-resolver": "^5.0.4",
     "jest": "^27.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2840,7 +2840,7 @@ electron-to-chromium@^1.4.17:
   version "1.4.68"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.68.tgz#d79447b6bd1bec9183f166bb33d4bef0d5e4e568"
 
-elliptic@6.5.4, elliptic@^6.5.3, elliptic@^6.5.4:
+elliptic@6.5.4, elliptic@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   dependencies:


### PR DESCRIPTION
- The test code still depends on it. We think it's not good to do it unless we find an alternative library usable with react native.